### PR TITLE
fix createComponent import

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ const {
   createState,
   createContext,
   useContext,
-  onCleanup
+  onCleanup,
+  createComponent
 } = require('solid-js')
-const { createComponent } = require('solid-js/dom')
 
 const StoreContext = createContext()
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "jest --coverage && yarn lint && size-limit"
   },
   "peerDependencies": {
-    "solid-js": "^0.18.0",
+    "solid-js": "^0.22.0",
     "storeon": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Latest Solid [release](https://github.com/ryansolid/solid/releases/tag/v0.24.0) removed `solid-js/dom`, this PR fix the import of `createComponent` and bump the Solid peerDependency to the first Solid version that exports `createComponent` from `solid-js`